### PR TITLE
Updating the linter. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ encrypted:
 ###### Adding interpolations
 An interpolation is a  value that will be dynamically substituted during generation with the correct value for the environment being generated. Interpolations are declared in the config for a given environment. Once declared an interpolation can be used in a property definition by referencing it in braces. If we were to reference the domain interpolation from the example config above we would use `{domain}`.
 
+Note: values that start with an interpolation must be placed in quotes (ex. "{xxx}.xxx.xxx.{xxx}"). 
+
 ##### Step 4: Generating Your Properties (Using the CLI)
 The bin directory contains the generator.rb cli. An example of running the cli is below. The `project_path` argument specifies the path to the properties repo we are generating a uploading properties from. You must be able to create a session with s3 to upload.
 ```sh

--- a/lib/linter/report.rb
+++ b/lib/linter/report.rb
@@ -41,6 +41,9 @@ module PropertyGenerator
       end
       table = Terminal::Table.new :headings => ['Files'], :title => 'Files Failing to Load', :rows => rows, :style => {:width => 200}
       puts table
+      puts "*****************"
+      puts "Check for property values that start with an interpolated value \nIf the first character of the value is a bracket yaml will fail to load \nPlace the value in quotes"
+      puts "*****************"
     end
 
     def make_pass_table

--- a/lib/linter/services_linter.rb
+++ b/lib/linter/services_linter.rb
@@ -14,6 +14,7 @@ module PropertyGenerator
 
     def run_services_tests
       tests = ['services_have_accepted_keys',
+               'service_environments_are_not_empty',
                'service_defaults_have_no_hashes_as_values',
                'service_environments_match_config_environments',
                'service_environments_have_no_hashes_as_values',
@@ -22,6 +23,25 @@ module PropertyGenerator
                'service_encrypted_region_field_is_accepted']
       results = PropertyGenerator.test_runner(self, tests)
       results
+    end
+
+    def service_environments_are_not_empty
+      status = {status: 'pass', error: ''}
+      services_empty_environments = []
+      @services.each do |path, loaded|
+        unless loaded['environments'] == nil
+          loaded['environments'].each do |environments, properties|
+            if properties == nil
+              services_empty_environments << {path => environments}
+            end
+          end
+        end
+      end
+      if services_empty_environments != []
+        status[:status] = 'fail'
+        status[:error] = "Service files #{services_empty_environments} have empty environments, these should be omitted."
+      end
+      status
     end
 
     def services_have_accepted_keys
@@ -91,9 +111,11 @@ module PropertyGenerator
       @services.each do |path, loaded|
         unless loaded['environments'] == nil
           loaded['environments'].each do |environments, properties|
-            properties.each do |key, value|
-              if value.class == Hash
-                services_with_hashes_in_environments << {path => {environments => key}}
+            unless properties == nil
+              properties.each do |key, value|
+                if value.class == Hash
+                  services_with_hashes_in_environments << {path => {environments => key}}
+                end
               end
             end
           end


### PR DESCRIPTION
Make linter catch and fail tests if there are empty environments.
Have a statement alerting people that they need to have quotes around values whose first character are a bracket