### PR TITLE
Add null check in ssm linting

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.2'
+  s.version     = '0.2.3'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."

--- a/lib/linter/services_linter.rb
+++ b/lib/linter/services_linter.rb
@@ -13,14 +13,16 @@ module PropertyGenerator
     end
 
     def run_services_tests
-      tests = ['services_have_accepted_keys',
-               'service_environments_are_not_empty',
-               'service_defaults_have_no_hashes_as_values',
-               'service_environments_match_config_environments',
-               'service_environments_have_no_hashes_as_values',
-               'service_encrypted_environments_match_config_environments',
-               'service_encrypted_fields_are_correct',
-               'service_encrypted_region_field_is_accepted']
+      tests = [
+        'services_have_accepted_keys',
+        'service_environments_are_not_empty',
+        'service_defaults_have_no_hashes_as_values',
+        'service_environments_match_config_environments',
+        'service_environments_have_no_hashes_as_values',
+        'service_encrypted_environments_match_config_environments',
+        'service_encrypted_fields_are_correct',
+        'service_encrypted_region_field_is_accepted'
+      ]
       results = PropertyGenerator.test_runner(self, tests)
       results
     end
@@ -161,6 +163,8 @@ module PropertyGenerator
           loaded['encrypted'].each do |environment, properties|
             properties.each do |property, value|
               if value == nil
+                services_with_unacceptable_keys << {path => {environment => property}}
+              elsif value['$ssm'] == nil
                 services_with_unacceptable_keys << {path => {environment => property}}
               else
                 if value['$ssm'] != nil


### PR DESCRIPTION
Adds a null check to the linter for the following case:

```yaml
my.property:
  $ssm:
  service: test-service
  region: us-east-1
  encrypted: fa09hjert09jewtrq9j0ewt09jwtj09t40jn4n243noin
```

A property like above will cause cps to panic, at least currently. Fix coming in on the cps side but this is still an invalid property and we should check for it.

Verified and tested on the offending branch.