### PR TITLE
 Add support for nested interpolations 

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.3'
+  s.version     = '0.2.5'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."


### PR DESCRIPTION
CPS v2 allows nested properties. Here, we add support for injecting
interpolations into those nested properties. The function added is
recursive so will allow for interpolations on any level of nesting.

There already seems to be a 0.2.4 tag, so we're skipping that and
going straight to 0.2.5 to prevent issues with the build process.