### PR TITLE
Writer return value now accurately points to the vpc directory if it …

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.5'
+  s.version     = '0.2.6'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."

--- a/lib/helpers/helpers.rb
+++ b/lib/helpers/helpers.rb
@@ -67,11 +67,12 @@ module PropertyGenerator
           vpc_dir = "#{output_path}/#{account}/#{region}/#{environmental_configs[env]["vpc"]}"
           FileUtils.mkdir_p("#{vpc_dir}/") unless Dir.exist?(vpc_dir)
           File.write("#{output_path}/#{account}/#{region}/#{environmental_configs[env]["vpc"]}/#{service_name}.json", json)
+          output << "#{output_path}/#{account}/#{region}/#{environmental_configs[env]["vpc"]}/#{service_name}.json"
         else
           FileUtils.mkdir_p("#{output_path}/#{account}/#{region}/") unless Dir.exist?("#{output_path}/#{account}/#{region}/")
           File.write("#{output_path}/#{account}/#{region}/#{service_name}.json", json)
+          output << "#{output_path}/#{account}/#{region}/#{service_name}.json"
         end
-        output << "#{output_path}/#{account}/#{region}/#{service_name}.json"
       end
       output
     end


### PR DESCRIPTION
…wrote files there

Currently, if the writer function makes/writes to a vpc directory, it still returns the path to a now non-existant json file in the parent directory (the old location of the file), which then chokes the uploader.

This is a quick fix to make sure that the correct path is written into the returned array.

