### PR TITLE
Fix linter for projects with non-regional environments

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.6'
+  s.version     = '0.2.7'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."

--- a/lib/linter/config_linter.rb
+++ b/lib/linter/config_linter.rb
@@ -14,7 +14,7 @@ module PropertyGenerator
       else
         tests = ['config_has_correct_keys',
                  'environment_configs_match_environments_list',
-                 'environment_configs_have_matching_region_and_account_values',
+                 'environment_configs_have_valid_region_and_account_values',
                  'environment_configs_have_well_formatted_interpolations',
                  'config_file_is_present']
       end
@@ -61,12 +61,12 @@ module PropertyGenerator
       status
     end
 
-    def environment_configs_have_matching_region_and_account_values
+    def environment_configs_have_valid_region_and_account_values
       status = {status: 'pass', error: ''}
       environments_missmatch_values = []
       any_missmatches = false
       @configs['environment_configs'].keys.each do |environment|
-        unless @configs['environments'].include?(@configs['environment_configs'][environment]['region']) && @configs['accounts'].include?(@configs['environment_configs'][environment]['account'])
+        unless (@configs['environment_configs'][environment].key?('region')) && @configs['accounts'].include?(@configs['environment_configs'][environment]['account'])
           environments_missmatch_values << environment
           any_missmatches = true
         end


### PR DESCRIPTION
When using solely named environments, the linter would give a false positive because there is not a region matching the named environment. This PR changes the linting logic to ensure that there is a top level region key for every environment instead of verifying that there is an environment that exists with a specific region's name. 