### PR TITLE
Log error and abort if the specified upload_account does not exist

### DIFF
--- a/bin/cps-property-generator
+++ b/bin/cps-property-generator
@@ -24,7 +24,6 @@ class GeneratorCLI < ::Thor
       else
         generator.upload(out, options)
       end
-
     end
   end
 

--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.8'
+  s.version     = '0.2.9'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."

--- a/lib/generator/generator.rb
+++ b/lib/generator/generator.rb
@@ -15,10 +15,11 @@ module PropertyGenerator
       @configs = PropertyGenerator::Config.new(project_path)
       @globals = PropertyGenerator::Globals.new(project_path, @configs)
       @globals = @globals.globals
+      @accounts = @configs.accounts
+
       @output_path =  "#{File.expand_path(options['output'])}/properties/#{SecureRandom.hex}"
       puts "Properties will be output here #{@output_path}"
       @service_list = PropertyGenerator.read_services(project_path)
-
     end
 
     def generate
@@ -36,6 +37,12 @@ module PropertyGenerator
     end
 
     def upload(out, config)
+      account = config['upload_account']
+
+      if !@accounts.include?(account.to_i)
+        abort("The specified account (#{account}) is not configured, please add it to config/config.yml")
+      end
+
       upload_account = config['upload_account']
       upload_region = config['upload_region']
       upload_bucket = config['upload_bucket']


### PR DESCRIPTION
Previously we were not logging an error if the specified `--upload_account` did not exist. With this PR we log an error and abort.