### PR TITLE
PD-26711 Adding support for picking up a configname from properties t…

### DIFF
--- a/lib/generator/generator.rb
+++ b/lib/generator/generator.rb
@@ -30,7 +30,7 @@ module PropertyGenerator
         service_instance.service
         service_instance.interpolate
 
-        out = PropertyGenerator.writer(service, service_instance.service, @configs, @output_path)
+        out = PropertyGenerator.writer(service, service_instance.service, @configs, @output_path, service_instance.configmap_name)
         (output << out).flatten!
       end
       output

--- a/lib/generator/service.rb
+++ b/lib/generator/service.rb
@@ -10,6 +10,7 @@ module PropertyGenerator
       @environments = config.environments
       @globals = globals
       @environment_configs = config.environment_configs
+      @configmapname = service_data['configname'].nil? ? nil : service_data['configname']
       set_service
     end
 
@@ -20,6 +21,10 @@ module PropertyGenerator
 
     def service
       @service
+    end
+
+    def configmap_name
+      @configmapname
     end
 
     def interpolate

--- a/lib/helpers/helpers.rb
+++ b/lib/helpers/helpers.rb
@@ -54,14 +54,18 @@ module PropertyGenerator
       end
     end
 
-    def writer(service_name, finalized, configs, output_path)
+    def writer(service_name, finalized, configs, output_path, configmap_name)
       output = []
       envs = configs.environments
       environmental_configs =  configs.environment_configs
       envs.each do | env|
         account = environmental_configs[env]["account"]
         region = environmental_configs[env]["region"]
-        json = JSON.pretty_generate({"properties" => finalized[env]})
+        json = if configmap_name
+          JSON.pretty_generate({"properties" => finalized[env],"configname" => configmap_name})
+        else
+          JSON.pretty_generate({"properties" => finalized[env]})
+        end
         #IF users are specifing a vpc then we will drop property files under the dir that corresponds to the vpc
         if environmental_configs[env].key?("vpc") && !environmental_configs[env]["vpc"].nil?
           vpc_dir = "#{output_path}/#{account}/#{region}/#{environmental_configs[env]["vpc"]}"

--- a/lib/linter/services_linter.rb
+++ b/lib/linter/services_linter.rb
@@ -48,7 +48,7 @@ module PropertyGenerator
 
     def services_have_accepted_keys
       status = {status: 'pass', error: ''}
-      accepted_keys = ['default', 'environments', 'encrypted']
+      accepted_keys = ['default', 'environments', 'encrypted', 'configname']
       services_with_unacceptable_keys = []
       @services.each do |path, loaded|
         loaded.keys.each do |service_key|
@@ -59,7 +59,7 @@ module PropertyGenerator
       end
       if services_with_unacceptable_keys != []
         status[:status] = 'fail'
-        status[:error] = "Service files: #{services_with_unacceptable_keys} have keys other than 'default', 'environments', or 'encrypted'."
+        status[:error] = "Service files: #{services_with_unacceptable_keys} have keys other than 'default', 'environments', 'encrypted', or 'configname'."
       end
       status
     end


### PR DESCRIPTION
…emplate to be passed into json if defined

Thanks Adam for pretty much doing all the ruby!

Adding option to be able to define a config file name as part of the initial properties template which will then be picked up if defined and added to the json which then gets copied to s3 bucket.  If configname is not defined behaves as normal.

Then we can amend the lambda to look for the extra configname as part of the json and if there handle to amend the configmap to be a single config file.

**Note** - Code as part of this PR could change dependant on how amending the lambda goes.

**Properties example**
---
default:
environments:
  ipims-staging-1:
    s3-base-url: http://bucket.ipims-staging-1.us-east-1.r7ops.com
    s3-bucket: bucket.ipims-staging-1.us-east-1.r7ops.com
    s3-endpoint: us-east-1
configname: test.properties

**Json example**
{
  "properties": {
    "DUMMY_VARIABLE3": true,
    "DUMMY_VARIABLE2": true,
    "DUMMY_VARIABLE1": true,
    "s3-base-url": "http://bucket.ipims-staging-1.us-east-1.r7ops.com",
    "s3-bucket": "bucket.ipims-staging-1.us-east-1.r7ops.com",
    "s3-endpoint": "us-east-1"
  },
  "configname": "test.properties"
}

https://issues.corp.rapid7.com/browse/PD-26711