### PR TITLE
Pd 26787 support additional options from properties to json

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.10'
+  s.version     = '0.2.11'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."

--- a/lib/generator/generator.rb
+++ b/lib/generator/generator.rb
@@ -30,7 +30,7 @@ module PropertyGenerator
         service_instance.service
         service_instance.interpolate
 
-        out = PropertyGenerator.writer(service, service_instance.service, @configs, @output_path, service_instance.configmap_name)
+        out = PropertyGenerator.writer(service, service_instance.service, @configs, @output_path, service_instance.additional_options)
         (output << out).flatten!
       end
       output

--- a/lib/generator/service.rb
+++ b/lib/generator/service.rb
@@ -11,12 +11,25 @@ module PropertyGenerator
       @globals = globals
       @environment_configs = config.environment_configs
       @configmapname = service_data['configname'].nil? ? nil : service_data['configname']
+      set_additional_options
       set_service
     end
 
     def set_service
       service_data = merge_env_default(@service_data, @environments)
       @service = merge_service_with_globals(@globals, service_data, @environments)
+    end
+
+    def set_additional_options
+      @additional_options = {}
+      @additional_options['configname'] = @service_data['configname'].nil? ? nil : @service_data['configname']
+      @additional_options['stringdata'] = @service_data['stringdata'].nil? ? nil : @service_data['stringdata']
+      @additional_options['configlabels'] = @service_data['configlabels'].nil? ? nil : @service_data['configlabels']
+      @additional_options['secretlabels'] = @service_data['secretlabels'].nil? ? nil : @service_data['secretlabels']
+    end
+
+    def additional_options
+      @additional_options
     end
 
     def service

--- a/lib/helpers/helpers.rb
+++ b/lib/helpers/helpers.rb
@@ -63,9 +63,9 @@ module PropertyGenerator
         region = environmental_configs[env]["region"]
         hash = { "properties" => finalized[env] }
         ['configname', 'stringdata', 'configlabels', 'secretlabels'].each do |setting|
-        hash[setting] = additional_options[setting] if [setting] unless additional_options[setting].nil?
+          hash[setting] = additional_options[setting] if [setting] unless additional_options[setting].nil?
         end
-          json = JSON.pretty_generate(hash)
+        json = JSON.pretty_generate(hash)
         #IF users are specifing a vpc then we will drop property files under the dir that corresponds to the vpc
         if environmental_configs[env].key?("vpc") && !environmental_configs[env]["vpc"].nil?
           vpc_dir = "#{output_path}/#{account}/#{region}/#{environmental_configs[env]["vpc"]}"

--- a/lib/helpers/helpers.rb
+++ b/lib/helpers/helpers.rb
@@ -54,18 +54,18 @@ module PropertyGenerator
       end
     end
 
-    def writer(service_name, finalized, configs, output_path, configmap_name)
+    def writer(service_name, finalized, configs, output_path, additional_options)
       output = []
       envs = configs.environments
       environmental_configs =  configs.environment_configs
       envs.each do | env|
         account = environmental_configs[env]["account"]
         region = environmental_configs[env]["region"]
-        json = if configmap_name
-          JSON.pretty_generate({"properties" => finalized[env],"configname" => configmap_name})
-        else
-          JSON.pretty_generate({"properties" => finalized[env]})
+        hash = { "properties" => finalized[env] }
+        ['configname', 'stringdata', 'configlabels', 'secretlabels'].each do |setting|
+        hash[setting] = additional_options[setting] if [setting] unless additional_options[setting].nil?
         end
+          json = JSON.pretty_generate(hash)
         #IF users are specifing a vpc then we will drop property files under the dir that corresponds to the vpc
         if environmental_configs[env].key?("vpc") && !environmental_configs[env]["vpc"].nil?
           vpc_dir = "#{output_path}/#{account}/#{region}/#{environmental_configs[env]["vpc"]}"

--- a/lib/linter/services_linter.rb
+++ b/lib/linter/services_linter.rb
@@ -48,7 +48,7 @@ module PropertyGenerator
 
     def services_have_accepted_keys
       status = {status: 'pass', error: ''}
-      accepted_keys = ['default', 'environments', 'encrypted', 'configname']
+      accepted_keys = ['default', 'environments', 'encrypted', 'configname', 'stringdata', 'configlabels', 'secretlabels']
       services_with_unacceptable_keys = []
       @services.each do |path, loaded|
         loaded.keys.each do |service_key|
@@ -59,7 +59,7 @@ module PropertyGenerator
       end
       if services_with_unacceptable_keys != []
         status[:status] = 'fail'
-        status[:error] = "Service files: #{services_with_unacceptable_keys} have keys other than 'default', 'environments', 'encrypted', or 'configname'."
+        status[:error] = "Service files: #{services_with_unacceptable_keys} have keys other than 'default', 'environments', 'encrypted', 'configname', 'stringdata' 'configlabels' or 'secretlabels'"
       end
       status
     end


### PR DESCRIPTION
Thanks again to Adam for helping with the ruby!

Adding support for more additional options to be passed in from the properties template to the json files.  If additional options are not defined, then they will not be processed and will not make it to the json

Additional options now supported in the properties template:

**configname** - as per previous PR - https://github.com/rapid7/cps-property-generator/pull/22 - which allows defining the config name and in turn create 1 single config file full of properties, e.g. var1=foo

**stringdata** - If true this means we will use stringdata as part of the secrets k8 yaml - which allows us to create a single secrets config file with what formating we like inside.  For example, a single secret config file with properties defined inside like secret1=top_secret
Reference - https://v1-16.docs.kubernetes.io/docs/concepts/configuration/secret/

**configlabels** - Allows to define labels which in turn can be used as labels for the configmap definition

**secretlabels** - Allows to define labels which in turn can be used as labels for the secret definition

Note - Development/testing is still required on the lamba side to support new json values.

**Properties example**
```yaml
---
default:
environments:
  ipims-staging-1:
    s3-base-url: http://bucket.ipims-staging-1.us-east-1.r7ops.com
    s3-bucket: bucket.ipims-staging-1.us-east-1.r7ops.com
    s3-endpoint: us-east-1
encrypted:
  ipims-staging-1:
    management.metrics.export.datadog.apiKey:
      $ssm:
        region: us-east-1
        encrypted: AQICAHhLzsMBGhdHhcDT1eugNokZgtQ4BynUYqeHCyuxog33ogGML4P/VG61omJFDrdRWMG3AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMnVr24NU5kO1Dln4rAgEQgDvl0H1urCkNYujN7Oh1a3cFbNlktUunXk+p3yHSm4mkLHfRu6fb9mC56LbztHm/y/PacHnnTUxE1qWFgQ==
    management.metrics.export.datadog.applicationKey:
      $ssm:
        region: us-east-1
        encrypted: AQICAHhLzsMBGhdHhcDT1eugNokZgtQ4BynUYqeHCyuxog33ogERqFXKnkEHv/YyhwAhvnuXAAAAhzCBhAYJKoZIhvcNAQcGoHcwdQIBADBwBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDF+LdTAFukEk9i3rLQIBEIBDBeGsQRgVnG74EYCstLQ1hZSAdyW7YMf5vq65WgHNGa5o7WJs3wCqVNz1u1tY6RTPR+Vxl2Xv9SWTPhlVz0z3E0nBsg==
configname: test.properties
stringdata: true
configlabels:
  configlabel: config_label
secretlabels:
  secretlabel: secret_label
```

**Json example**
```json
{
  "properties": {
    "DUMMY_VARIABLE3": true,
    "DUMMY_VARIABLE2": true,
    "DUMMY_VARIABLE1": true,
    "s3-base-url": "http://bucket.ipims-staging-1.us-east-1.r7ops.com",
    "s3-bucket": "bucket.ipims-staging-1.us-east-1.r7ops.com",
    "s3-endpoint": "us-east-1",
    "management.metrics.export.datadog.apiKey": {
      "$ssm": {
        "service": "test-config-secret",
        "region": "us-east-1",
        "encrypted": "AQICAHhLzsMBGhdHhcDT1eugNokZgtQ4BynUYqeHCyuxog33ogFI+HElfDL+ZlNskEEdmvNvAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMW5BlLroz57OqmT7tAgEQgDsaRQ7Z5qS4U54esEfvowC9pugfKNrnTw+rvKb22SLEw0IbWJWQJsuCiVOGA89cKncfG3IlQD4o3Kyx8A=="
      }
    },
    "management.metrics.export.datadog.applicationKey": {
      "$ssm": {
        "service": "test-config-secret",
        "region": "us-east-1",
        "encrypted": "AQICAHhLzsMBGhdHhcDT1eugNokZgtQ4BynUYqeHCyuxog33ogGY4nj4dySiZgqEt6eGoARLAAAAhzCBhAYJKoZIhvcNAQcGoHcwdQIBADBwBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDF4wBO/klmz3ekSkPgIBEIBD1FraaUwjQg4fHIbm9giXpzTWrKJi6goaLALjmPqlMyyjVQSnBfawbM1KtB/o3t1iUHKolIGAmxvdA8cuHC2LQaQiOw=="
      }
    }
  },
  "configname": "test.properties",
  "stringdata": true,
  "configlabels": {
    "configlabel": true
  },
  "secretlabels": {
    "secretlabel": true
  }
}
```

https://issues.corp.rapid7.com/browse/PD-26787