### PR TITLE
Fix: Type mismatch on upload account check

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.2.20'
+  s.version     = '0.2.21'
   s.date        = '2018-07-12'
   s.summary     = "Centralized Property Service json file generator "
   s.description = "Generates json property files from yaml definitions to be served up by CPS."

--- a/lib/generator/generator.rb
+++ b/lib/generator/generator.rb
@@ -48,8 +48,10 @@ module PropertyGenerator
           PropertyGenerator.sync(upload_region, file_account, upload_bucket, file, file_region)
         end
       else
-        upload_account = config['upload_account']
-        abort("The specified account (#{upload_account}) is not configured, please add it to config/config.yml") unless @accounts.include?(upload_account)
+        upload_account = config['upload_account'].strip
+        unless @accounts.map { |a| a.to_s.strip }.include?(upload_account)
+          abort("The specified account (#{upload_account}) is not configured, please add it to config/config.yml")
+        end
 
         upload_out = out.select { |file| file.include?("#{upload_account}") && file.include?("#{upload_region}") }
         _upload_files(upload_out) do |file|


### PR DESCRIPTION
This PR fixes an issue where YAML can parse an unquoted account number in the `config.yml` as an integer but the `upload_account` parameter is always a string. The fix is to ensure that accounts are converted to strings before checking if the upload account is in that list.