### PR TITLE
PD-28637 - Adding rexml dependancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+cps-property-generator-*.gem

--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.3.2'
+  s.version     = '0.3.3'
   s.summary     = 'Centralized Property Service json file generator'
   s.description = 'Generates json property files from yaml definitions to be served up by CPS.'
   s.authors     = ['Bryan Call']
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'thor'
   s.add_dependency 'thor-scmversion'
   s.add_dependency 'webrick'
+  s.add_dependency 'rexml'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
Adding rexml dependancy as getting error on out of the box amazon linux images

This is for using CPS in EKS

```
/usr/local/share/gems/gems/aws-sdk-core-3.115.0/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)
```