### PR TITLE
Bumped version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 gem 'activesupport', '~> 4.2.11.1'
-gem 'aws-sdk-s3', '~> 1.0.0.rc2'
+gem 'aws-sdk-s3', '~> 1.117.2'
 gem 'rspec'
 gem 'rubocop'
 gem 'rubocop-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,26 +7,27 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     ast (2.4.2)
-    aws-eventstream (1.0.1)
-    aws-partitions (1.96.0)
-    aws-sdk-core (3.22.1)
-      aws-eventstream (~> 1.0)
-      aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.0)
-      jmespath (~> 1.0)
-    aws-sdk-kms (1.6.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.0.0)
-      aws-sdk-core (~> 3)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.691.0)
+    aws-sdk-core (3.168.4)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.61.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.117.2)
+      aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.0.3)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jmespath (1.4.0)
+    jmespath (1.6.2)
     minitest (5.12.2)
     mixlib-shellout (2.3.2)
     parallel (1.20.1)
@@ -79,7 +80,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 4.2.11.1)
-  aws-sdk-s3 (~> 1.0.0.rc2)
+  aws-sdk-s3 (~> 1.117.2)
   rspec
   rubocop
   rubocop-rspec
@@ -88,4 +89,4 @@ DEPENDENCIES
   thor-scmversion (= 1.7.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cps-property-generator'
-  s.version     = '0.3.4'
+  s.version     = '0.3.7'
   s.summary     = 'Centralized Property Service json file generator'
   s.description = 'Generates json property files from yaml definitions to be served up by CPS.'
   s.authors     = ['Bryan Call']
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.bindir      = 'bin'
 
   s.add_dependency 'activesupport', '~> 4.2.11.1'
-  s.add_dependency 'aws-sdk-s3', '~> 1.0.0.rc2'
+  s.add_dependency 'aws-sdk-s3', '~> 1.117.2'
   s.add_dependency 'terminal-table'
   s.add_dependency 'thor'
   s.add_dependency 'thor-scmversion'


### PR DESCRIPTION
This PR bumps the spec version to 0.3.7 which is the current tag. I'll build and push this manually so that what's in rubygems.org is consistent with the tag we have in this repo.