### PR TITLE
PD-46395 - Generate function - Permitted classes - Time

### DIFF
--- a/cps-property-generator.gemspec
+++ b/cps-property-generator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "cps-property-generator"
-  s.version = "0.4.0"
+  s.version = "0.4.1"
   s.summary = "Centralized Property Service json file generator"
   s.description = "Generates json property files from yaml definitions to be served up by CPS."
   s.authors = ["Bryan Call"]

--- a/lib/generator/generator.rb
+++ b/lib/generator/generator.rb
@@ -26,7 +26,7 @@ module PropertyGenerator
       output = []
       @service_list.each do |service, path|
         PropertyGenerator.config_enforcer(@configs.environment_configs)
-        service_instance = PropertyGenerator::Service.new(YAML.load_file(path), @configs, @globals)
+        service_instance = PropertyGenerator::Service.new(YAML.load_file(path, permitted_classes: [Time]), @configs, @globals)
         service_instance.service
         service_instance.interpolate
 


### PR DESCRIPTION
Seeing this error when testing on further cps repos

This PR is to permit this class

```
/home/jenkins/.rvm/rubies/ruby-3.3.3/lib/ruby/3.3.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Time (Psych::DisallowedClass)
```